### PR TITLE
Update exit.c with a custom log message in the `do_exit` function

### DIFF
--- a/kernel/exit.c
+++ b/kernel/exit.c
@@ -907,6 +907,8 @@ void __noreturn do_exit(long code)
 	ptrace_event(PTRACE_EVENT_EXIT, code);
 	user_events_exit(tsk);
 
+	pr_info("Process name: %s | PID: %d | Exiting with code: %ld\n", task>comm, tsk->pid, code);
+
 	io_uring_files_cancel();
 	exit_signals(tsk);  /* sets PF_EXITING */
 


### PR DESCRIPTION
Adding a custom log message to the function, to log the process name, identifier and exit code for each process when it exits.